### PR TITLE
Ttl as duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Adding more caches and configuration options is relatively simple, and a matter
 of parsing attribute parameters. Currently, compiling will fail if you use a
 parameter such as `Capacity` without the feature `full` being enabled.
 
+
+Another parameter is TimeToLive. Example:
+```rust
+#[memoize(Capacity: 123, TimeToLive: Duration::from_secs(2))]
+```
+chrono::Duration is also possible, but have to be converted into std::time::Duration
+```rust
+#[memoize(TimeToLive: chrono::Duration::hours(3).to_std().unwrap())]
+```
+
 ## Contributions
 
 ...are always welcome! This being my first procedural-macros crate, I am

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ of parsing attribute parameters. Currently, compiling will fail if you use a
 parameter such as `Capacity` without the feature `full` being enabled.
 
 
-Another parameter is TimeToLive - it targeting to refresh outdated values.
+Another parameter is TimeToLive - it's targeting to refresh outdated values.
 Example:
 ```rust
 #[memoize(Capacity: 123, TimeToLive: Duration::from_secs(2))]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ of parsing attribute parameters. Currently, compiling will fail if you use a
 parameter such as `Capacity` without the feature `full` being enabled.
 
 
-Another parameter is TimeToLive. Example:
+Another parameter is TimeToLive - it targeting to refresh outdated values.
+Example:
 ```rust
 #[memoize(Capacity: 123, TimeToLive: Duration::from_secs(2))]
 ```
@@ -86,6 +87,7 @@ chrono::Duration is also possible, but have to be converted into std::time::Dura
 ```rust
 #[memoize(TimeToLive: chrono::Duration::hours(3).to_std().unwrap())]
 ```
+cached value will be actual no longer than duration provided and refreshed with next request.
 
 ## Contributions
 

--- a/examples/test1.rs
+++ b/examples/test1.rs
@@ -9,7 +9,7 @@ struct ComplexStruct {
     i: Instant,
 }
 
-#[memoize(Capacity: 123, SecondsToLive: Duration::from_secs(2))]
+#[memoize(Capacity: 123, TimeToLive: Duration::from_secs(2))]
 fn hello(key: String) -> ComplexStruct {
     println!("hello: {}", key);
     ComplexStruct {

--- a/examples/test1.rs
+++ b/examples/test1.rs
@@ -19,11 +19,16 @@ fn hello(key: String) -> ComplexStruct {
     }
 }
 
+
+
 fn main() {
     println!("result: {:?}", hello("ABC".to_string()));
     println!("result: {:?}", hello("DEF".to_string()));
     println!("result: {:?}", hello("ABC".to_string()));  //Same as first
     thread::sleep(Duration::from_millis(2100));
+    println!("result: {:?}", hello("EFG".to_string()));
     println!("result: {:?}", hello("ABC".to_string()));  //Refreshed
+    println!("result: {:?}", hello("EFG".to_string()));  //Same as first
+    println!("result: {:?}", hello("ABC".to_string()));  //Same as refreshed
     println!("result: {:?}", memoized_original_hello("ABC".to_string()));
 }

--- a/examples/test1.rs
+++ b/examples/test1.rs
@@ -1,25 +1,29 @@
 use memoize::memoize;
+use std::time::{Instant, Duration};
+use std::thread;
 
 #[derive(Debug, Clone)]
 struct ComplexStruct {
     s: String,
     b: bool,
-    i: i32,
+    i: Instant,
 }
 
-#[memoize(Capacity: 123)]
+#[memoize(Capacity: 123, SecondsToLive: 1)]
 fn hello(key: String) -> ComplexStruct {
     println!("hello: {}", key);
     ComplexStruct {
         s: key,
         b: false,
-        i: 332,
+        i: Instant::now(),
     }
 }
 
 fn main() {
     println!("result: {:?}", hello("ABC".to_string()));
     println!("result: {:?}", hello("DEF".to_string()));
-    println!("result: {:?}", hello("ABC".to_string()));
+    println!("result: {:?}", hello("ABC".to_string()));  //Same as first
+    thread::sleep(Duration::from_millis(2100));
+    println!("result: {:?}", hello("ABC".to_string()));  //Refreshed
     println!("result: {:?}", memoized_original_hello("ABC".to_string()));
 }

--- a/examples/test1.rs
+++ b/examples/test1.rs
@@ -9,7 +9,7 @@ struct ComplexStruct {
     i: Instant,
 }
 
-#[memoize(Capacity: 123, SecondsToLive: 1)]
+#[memoize(Capacity: 123, SecondsToLive: Duration::from_secs(2))]
 fn hello(key: String) -> ComplexStruct {
     println!("hello: {}", key);
     ComplexStruct {

--- a/examples/test1.rs
+++ b/examples/test1.rs
@@ -9,7 +9,7 @@ struct ComplexStruct {
     i: Instant,
 }
 
-#[memoize(Capacity: 123, TimeToLive: Duration::from_secs(2))]
+#[memoize(TimeToLive: Duration::from_secs(2), Capacity: 123)]
 fn hello(key: String) -> ComplexStruct {
     println!("hello: {}", key);
     ComplexStruct {
@@ -25,7 +25,7 @@ fn main() {
     println!("result: {:?}", hello("ABC".to_string()));
     println!("result: {:?}", hello("DEF".to_string()));
     println!("result: {:?}", hello("ABC".to_string()));  //Same as first
-    thread::sleep(Duration::from_millis(2100));
+    thread::sleep(core::time::Duration::from_millis(2100));
     println!("result: {:?}", hello("EFG".to_string()));
     println!("result: {:?}", hello("ABC".to_string()));  //Refreshed
     println!("result: {:?}", hello("EFG".to_string()));  //Same as first

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,9 @@ mod store {
  * The `memoize` attribute can take further parameters in order to use an LRU cache:
  * `#[memoize(Capacity: 1234)]`. In that case, instead of a `HashMap` we use an `lru::LruCache`
  * with the given capacity.
+ * `#[memoize(TimeToLive: Duration::from_secs(2))]`. In that case, cached walue will be actual
+ * no longer than duration provided and refreshed with next request. If you prefer chrono::Duration,
+ * it can be also used: `#[memoize(TimeToLive: chrono::Duration::hours(9).to_std().unwrap()]`
  *
  * This mechanism can, in principle, be extended (in the source code) to any other cache mechanism.
  *

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@ use syn;
 use syn::{parse_macro_input, spanned::Spanned, ItemFn};
 
 use proc_macro::TokenStream;
-use quote::{self, ToTokens};
+use quote::{self};
+use syn::export::ToTokens;
 
 // This implementation of the storage backend does not depend on any more crates.
 #[cfg(not(feature = "full"))]
@@ -46,11 +47,9 @@ mod store {
 #[cfg(feature = "full")]
 mod store {
     use proc_macro::TokenStream;
-    use syn::{parse as p, ExprCall, ExprMethodCall, Expr};
+    use syn::{parse as p, Expr};
     use syn::export::ToTokens;
-    use syn::spanned::Spanned;
-    use std::ops::Deref;
-    use syn::parse::{Parser, Parse};
+
 
     #[derive(Default, Clone)]
     pub(crate) struct CacheOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,7 @@ mod store {
 #[cfg(feature = "full")]
 mod store {
     use proc_macro::TokenStream;
-    use syn::{parse as p, ExprCall};
-    use std::time::Duration;
+    use syn::{parse as p, ExprCall, ExprMethodCall, Expr};
     use syn::export::ToTokens;
     use syn::spanned::Spanned;
     use std::ops::Deref;
@@ -56,13 +55,13 @@ mod store {
     #[derive(Default, Clone)]
     pub(crate) struct CacheOptions {
         lru_max_entries: Option<usize>,
-        pub(crate) time_to_live: Option<ExprCall>,
+        pub(crate) time_to_live: Option<Expr>,
     }
 
     #[derive(Clone)]
     enum CacheOption {
         LRUMaxEntries(usize),
-        TimeToLive(ExprCall),
+        TimeToLive(Expr),
     }
 
     syn::custom_keyword!(Capacity);
@@ -83,7 +82,7 @@ mod store {
             if la.peek(TimeToLive) {
                 let _: TimeToLive = input.parse().unwrap();
                 let _: Colon = input.parse().unwrap();
-                let cap: syn::ExprCall = input.parse().unwrap();
+                let cap: syn::Expr = input.parse().unwrap();
 
                 return Ok(CacheOption::TimeToLive(cap));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ mod store {
  * The `memoize` attribute can take further parameters in order to use an LRU cache:
  * `#[memoize(Capacity: 1234)]`. In that case, instead of a `HashMap` we use an `lru::LruCache`
  * with the given capacity.
- * `#[memoize(TimeToLive: Duration::from_secs(2))]`. In that case, cached walue will be actual
+ * `#[memoize(TimeToLive: Duration::from_secs(2))]`. In that case, cached value will be actual
  * no longer than duration provided and refreshed with next request. If you prefer chrono::Duration,
  * it can be also used: `#[memoize(TimeToLive: chrono::Duration::hours(9).to_std().unwrap()]`
  *

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ mod store {
     }
 
     syn::custom_keyword!(Capacity);
-    syn::custom_keyword!(SecondsToLive);
+    syn::custom_keyword!(TimeToLive);
     syn::custom_punctuation!(Colon, :);
 
     // To extend option parsing, add functionality here.
@@ -80,8 +80,8 @@ mod store {
 
                 return Ok(CacheOption::LRUMaxEntries(cap.base10_parse()?));
             }
-            if la.peek(SecondsToLive) {
-                let _: SecondsToLive = input.parse().unwrap();
+            if la.peek(TimeToLive) {
+                let _: TimeToLive = input.parse().unwrap();
                 let _: Colon = input.parse().unwrap();
                 let cap: syn::ExprCall = input.parse().unwrap();
 


### PR DESCRIPTION
Debug was removed from derive because of
```rust
syn::Expr` cannot be formatted using `{:?}` because it doesn't implement `Debug`
```