### PR TITLE
Restrict syn version to <1.0.58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 lazy_static = "1.4"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "<1.0.58", features = ["full"] }
 
 lru = { version = "0.6", optional = true }
 


### PR DESCRIPTION
Fix for #5.

```
$ cargo build
   Compiling proc-macro2 v1.0.24
   Compiling unicode-xid v0.2.1
   Compiling syn v1.0.57
   Compiling lazy_static v1.4.0
   Compiling quote v1.0.9
   Compiling memoize v0.1.6 (/home/k/repos/memoize)
    Finished dev [unoptimized + debuginfo] target(s) in 7.20s
```