### PR TITLE
Specify minimum version for syn dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 lazy_static = "1.4"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "<1.0.58", features = ["full"] }
+syn = { version = "1.0, <1.0.58", features = ["full"] }
 
 lru = { version = "0.6", optional = true }
 


### PR DESCRIPTION
With only an upper bound for the versioned dependency on syn, cargo can, and sometimes will, use a version <1.0 of syn.
Example:

[dependencies]
memoize = "0.1.7"
parse-display = "0.4.0"

$ cargo tree
[...]
├── memoize v0.1.7
│   └── syn v0.15.44
[...]
└── parse-display v0.5.1
[...]
    ├── parse-display-derive v0.5.1
    │   └── syn v1.0.73 (*)
[...]

To fix this, also specify a lower bound.