### PR TITLE
Fix compatibility with current version of syn crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 lazy_static = "1.4"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0, <1.0.58", features = ["full"] }
+syn = { version = "1.0", features = ["full"] }
 
 lru = { version = "0.6", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 #![crate_type = "proc-macro"]
 #![allow(unused_imports)] // Spurious complaints about a required trait import.
 
-use syn::{self, export::ToTokens, parse_macro_input, spanned::Spanned, ItemFn};
+use syn::{self, parse_macro_input, spanned::Spanned, ItemFn};
 
 use proc_macro::TokenStream;
-use quote::{self};
+use quote::{self, ToTokens};
 
 // This implementation of the storage backend does not depend on any more crates.
 #[cfg(not(feature = "full"))]
@@ -46,7 +46,6 @@ mod store {
 #[cfg(feature = "full")]
 mod store {
     use proc_macro::TokenStream;
-    use syn::export::ToTokens;
     use syn::{parse as p, Expr};
 
     #[derive(Default, Clone)]


### PR DESCRIPTION
I had a look at the reason for the incompatibility with recent versions of syn, and it turned out to be easily resolved.