### PR TITLE
bump lru version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 
 memoize-inner = { path = "inner/", version = "0.2.1" }
 lazy_static = "1.4"
-lru = { version = "0.6", optional = true }
+lru = { version = "0.7", optional = true }
 
 [workspace]
 members = ["inner/"]


### PR DESCRIPTION
cargo audit advisory

```
Crate:     lru
Version:   0.6.6
Title:     Use after free in lru crate
Date:      2021-12-21
ID:        RUSTSEC-2021-0130
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0130
Solution:  Upgrade to >=0.7.1
```