### PR TITLE
Add `compile_error`

### DIFF
--- a/inner/src/lib.rs
+++ b/inner/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_type = "proc-macro"]
 #![allow(unused_imports)] // Spurious complaints about a required trait import.
-
 use syn::{self, parse, parse_macro_input, spanned::Spanned, Expr, ExprCall, ItemFn, Path};
 
 use proc_macro::TokenStream;
@@ -179,7 +178,10 @@ mod store {
             }
             Some(cap) => {
                 if let Some(_) = &options.custom_hasher {
-                    panic!("You can't use LRUMaxEntries and a Custom Hasher. Remove `LRUMaxEntries` from the attribute");
+                    (
+                        quote::quote! { compile_error!("Cannot use LRU cache and a custom hasher at the same time") },
+                        quote::quote! { std::collections::HashMap::new() },
+                    )
                 } else {
                     (
                         quote::quote! { ::memoize::lru::LruCache<#key_type, #value_type> },


### PR DESCRIPTION
In #23, the idea of implementing a custom error handler was discussed. In #24 I tried doing just that and it didn't worked. So seeing that implementing a custom error handler will be inviable, this PR aims to change that temporary change (panicking) to a better one, using `compile_error!(...)`.

Being that we cannot use `miette`, at least use `compile_error!(...)`