### PR TITLE
Add ability to Ignore arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ As some hashers initializing functions other than `new()`, you can specifiy a `H
 #[memoize(CustomHasher: FxHashMap, HasherInit: FxHashMap::default())]
 ```
 
+Sometimes, you can't or don't want to store data as part of the cache. In those cases, you can use
+the `Ignore` parameter in the `#[memoize]` macro to ignore an argument. Any `Ignore`d arguments no
+longer need to be `Clone`-able, since they are not stored as part of the argument set, and changing
+an `Ignore`d argument will not trigger calling the function again. You can `Ignore` multiple
+arugments by specifying the `Ignore` parameter multiple times.
+
+```rust
+// `Ignore: count_calls` lets our function take a `&mut u32` argument, which is normally not
+// possible because it is not `Clone`-able.
+#[memoize(Ignore: count_calls)]
+fn add(a: u32, b: u32, count_calls: &mut u32) -> u32 {
+    // Keep track of the number of times the underlying function is called.
+	*count_calls += 1;
+	a + b
+}
+```
+
 ### Flushing
 
 If you memoize a function `f`, there will be a function called

--- a/examples/ignore.rs
+++ b/examples/ignore.rs
@@ -19,7 +19,6 @@ fn add2(a: u32, b: u32, call_count: &mut u32) -> u32 {
     a + b
 }
 
-#[cfg(feature = "full")]
 fn main() {
     // Note that the third argument is not `Clone` but can still be passed through.
     assert_eq!(add(1, 2, C {c: 3}, 4), 10);

--- a/examples/ignore.rs
+++ b/examples/ignore.rs
@@ -1,0 +1,42 @@
+use memoize::memoize;
+
+/// Wrapper struct for a [`u32`].
+///
+/// Note that A deliberately does not implement [`Clone`] or [`Hash`], to demonstrate that it can be
+/// passed through.
+struct C {
+    c: u32
+}
+
+#[memoize(Ignore: a, Ignore: c)]
+fn add(a: u32, b: u32, c: C, d: u32) -> u32 {
+    a + b + c.c + d
+}
+
+#[memoize(Ignore: call_count, SharedCache)]
+fn add2(a: u32, b: u32, call_count: &mut u32) -> u32 {
+    *call_count += 1;
+    a + b
+}
+
+#[cfg(feature = "full")]
+fn main() {
+    // Note that the third argument is not `Clone` but can still be passed through.
+    assert_eq!(add(1, 2, C {c: 3}, 4), 10);
+
+    assert_eq!(add(3, 2, C {c: 4}, 4), 10);
+    memoized_flush_add();
+
+    // Once cleared, all arguments is again used.
+    assert_eq!(add(3, 2, C {c: 4}, 4), 13);
+
+    let mut count_unique_calls = 0;
+    assert_eq!(add2(1, 2, &mut count_unique_calls), 3);
+    assert_eq!(count_unique_calls, 1);
+
+    // Calling `add2` again won't increment `count_unique_calls`
+    // because it's ignored as a parameter, and the other arguments
+    // are the same.
+    add2(1, 2, &mut count_unique_calls);
+    assert_eq!(count_unique_calls, 1);
+}

--- a/inner/src/lib.rs
+++ b/inner/src/lib.rs
@@ -278,7 +278,7 @@ pub fn memoize(attr: TokenStream, item: TokenStream) -> TokenStream {
     let flush_name = syn::Ident::new(format!("memoized_flush_{}", fn_name).as_str(), sig.span());
     let map_name = format!("memoized_mapping_{}", fn_name);
 
-    if let syn::FnArg::Receiver(_) = sig.inputs[0] {
+    if let Some(syn::FnArg::Receiver(_)) = sig.inputs.first() {
         return quote::quote! { compile_error!("Cannot memoize methods!"); }.into();
     }
 

--- a/inner/src/lib.rs
+++ b/inner/src/lib.rs
@@ -218,11 +218,11 @@ mod store {
 /**
  * memoize is an attribute to create a memoized version of a (simple enough) function.
  *
- * So far, it works on functions with one or more arguments which are `Clone`- and `Hash`-able,
- * returning a `Clone`-able value. Several clones happen within the storage and recall layer, with
- * the assumption being that `memoize` is used to cache such expensive functions that very few
- * `clone()`s do not matter. `memoize` doesn't work on methods (functions with `[&/&mut/]self`
- * receiver).
+ * So far, it works on non-method functions with one or more arguments returning a [`Clone`]-able
+ * value. Arguments that are cached must be [`Clone`]-able and [`Hash`]-able as well. Several clones
+ * happen within the storage and recall layer, with the assumption being that `memoize` is used to
+ * cache such expensive functions that very few `clone()`s do not matter. `memoize` doesn't work on
+ * methods (functions with `[&/&mut/]self` receiver).
  *
  * Calls are memoized for the lifetime of a program, using a statically allocated, Mutex-protected
  * HashMap.
@@ -245,6 +245,10 @@ mod store {
  * If you need to use the un-memoized function, it is always available as `memoized_original_{fn}`,
  * in this case: `memoized_original_hello()`.
  *
+ * Parameters can be ignored by the cache using the `Ignore` parameter. `Ignore` can be specified
+ * multiple times, once per each parameter. `Ignore`d parameters do not need to implement [`Clone`]
+ * or [`Hash`]. 
+ * 
  * See the `examples` for concrete applications.
  *
  * *The following descriptions need the `full` feature enabled.*


### PR DESCRIPTION
This PR adds an `Ignore` parameter to the `memoize` macro, allowing the user to mark one or more function arguments to not participate in the memoization. As a result, any `Ignore`d argument does not need to implement `Clone` or `Hash`, and changes to those arguments do **not** trigger re-invoking the original function.